### PR TITLE
viscio.py: Fixed type error in slice index

### DIFF
--- a/src/viscio.py
+++ b/src/viscio.py
@@ -34,7 +34,7 @@ def _list2float(seq):
 def autocorrelate (a):
     b=np.concatenate((a,np.zeros(len(a))),axis=0)
     c= np.fft.ifft(np.fft.fft(b)*np.conjugate(np.fft.fft(b))).real
-    d=c[:len(c)/2]
+    d=c[:int(len(c)/2)]
     d=d/(np.array(range(len(a)))+1)[::-1]
     return d
 


### PR DESCRIPTION
 This fixes the following error log:

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/home/amritagos/Git/Github/PR/PyLAT/src/viscio.py", line 37, in autocorrelate
    d=c[:len(c)/2]
TypeError: slice indices must be integers or None or have an __index__ method
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "../../../PyLAT.py", line 331, in <module>
    output = cv.calcvisc(arg.Visc_Num,arg.Visc_Skip,arg.Visc_Dir,arg.LOG[0],output, arg.verbose, arg.Visc_Samples, arg.Visc_Num_Boots, arg.Visc_Plot, arg.Visc_Guess)
  File "/home/amritagos/Git/Github/PR/PyLAT/src/calcVisc.py", line 46, in calcvisc
    (Time,visco)=Log.viscosity(numskip)
  File "/home/amritagos/Git/Github/PR/PyLAT/src/viscio.py", line 157, in viscosity
    pv=p.map(autocorrelate,array_array)
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 268, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 657, in get
    raise self._value
TypeError: slice indices must be integers or None or have an __index__ method
```